### PR TITLE
Added codeina docs, resolves #7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ pom.xml.asc
 .nrepl-history
 /.repl/*
 /out/*
+/doc
 *.iml
 examples/*/checkouts

--- a/project.clj
+++ b/project.clj
@@ -3,11 +3,18 @@
   :url "http://github.com/jamesmacaulay/zelkova"
   :license {:name "MIT License"
             :url "http://opensource.org/licenses/MIT"}
-  :dependencies [[org.clojure/clojure "1.7.0-beta1"]
-                 [org.clojure/clojurescript "0.0-3196"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
+                 [org.clojure/clojurescript "0.0-3308"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]]
   :plugins [[lein-cljsbuild "1.0.5"]
-            [com.cemerick/clojurescript.test "0.3.3"]]
+            [com.cemerick/clojurescript.test "0.3.3"]
+            [funcool/codeina "0.3.0-SNAPSHOT"]]
+
+  :codeina {:source ["src"]
+            :reader :clojurescript
+            :src-uri "http://github.com/jamesmacaulay/zelkova/blob/master/"
+            :src-uri-prefix "#L"}
+
   :aliases {"repl" ["with-profile" "repl" "repl"]
             "cljs-test" ["cljsbuild" "test"]
             "cljs-autotest" ["cljsbuild" "auto" "test"]
@@ -27,7 +34,7 @@
                         :notify-command ["phantomjs" :cljs.test/runner "target/testable.js"]
                         :compiler {:output-to "target/testable.js"
                                    :libs [""]
-                                   ; node doesn't like source maps I guess?
-                                   ;:source-map "target/testable.js.map"
+                                        ; node doesn't like source maps I guess?
+                                        ;:source-map "target/testable.js.map"
                                    :optimizations :simple
                                    :pretty-print true}}]})


### PR DESCRIPTION
The docs are generated with `lein doc` and appear under `/doc` which was added to `.gitignore`.